### PR TITLE
add error skipping

### DIFF
--- a/tasks/penthouse.js
+++ b/tasks/penthouse.js
@@ -20,7 +20,11 @@ module.exports = function (grunt) {
 		penthouse(options, function (err, result) {
 			if (err) {
 				if (err.msg) { grunt.log.errorlns(err.msg); }
-				done(false);
+				grunt.log.error(err);
+				if(options.skipErrors)
+					done();
+				else
+					done(false);
 				return;
 			}
 

--- a/tasks/penthouse.js
+++ b/tasks/penthouse.js
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
 					done(false);
 				return;
 			}
-
+			grunt.log.writeln("Done!");
 			grunt.log.debug(result);
 
 			grunt.file.write(options.outfile, result, {});


### PR DESCRIPTION
Add a parameter to skip errors and show warning/error on fail

* skipErrors: continue the process even on connection fail/other errors

Add this controller for multi task processes with different processors, in case someone need to build-up other tasks without penthouse,

Added "Done!" message.