### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,11 @@
     "url": "http://github.com/fatso83"
   },
   "scripts": {
-      "lint" : "grunt jshint",
-      "test" : "grunt test"
+    "test": "grunt test"
   },
   "pre-commit": [
-      "lint",
-      "test"
+    "lint",
+    "test"
   ],
   "repository": {
     "type": "git",
@@ -32,9 +31,6 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "scripts": {
-    "test": "grunt test"
-  },
   "dependencies": {
     "penthouse": ">= 0.5.0 <1.0.0)"
   },
@@ -51,7 +47,7 @@
     "pre-commit": "^1.1.2"
   },
   "peerDependencies": {
-    "grunt": "~0.4.2"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
